### PR TITLE
issue 37 fix  & updated google services dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.3'
-        classpath 'com.google.gms:google-services:3.2.1'
+        classpath 'com.google.gms:google-services:4.3.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/lib/profile/model.dart
+++ b/lib/profile/model.dart
@@ -54,7 +54,7 @@ class User {
         "mobileNumber": mobileNumber,
         "isPresent": isPresent,
         "isContributor": isContributor,
-        "registration": occupation.toJson(),
+        "registration": occupation?.toJson(),
       };
 
   User.fromSnapshot(DocumentSnapshot snapshot)


### PR DESCRIPTION
1. update google-services dependency from 3.2.1 to 4.3.3
^ update required due to following error: **E:\Installations\flutter_windows_v1.0.0-stable\flutter\.pub-cache\hosted\pub.dartlang.org\firebase_core-0.4.2+1\android\src\main\java\io\flutter\plugins\firebase\core\FirebaseCorePlugin.java uses or overrides a deprecated API.**


2.Fixed issue # 37 - bug: GET Started action not working due to null ocupation